### PR TITLE
Serve using mapproxy-util instead of uwsgi

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -14,4 +14,4 @@ fi
 cd /mapproxy
 su $USER_NAME -c "mapproxy-util create -t wsgi-app -f mapproxy.yaml /mapproxy/app.py"
 #su $USER_NAME -c "uwsgi --ini /uwsgi.conf"
-su $USER_NAME -c "/venv/bin/mapproxy-util serve-develop -b 0.0.0.0:8080 mapproxy.yaml"
+su $USER_NAME -c "mapproxy-util serve-develop -b 0.0.0.0:8080 mapproxy.yaml"

--- a/start.sh
+++ b/start.sh
@@ -13,5 +13,5 @@ then
 fi
 cd /mapproxy
 su $USER_NAME -c "mapproxy-util create -t wsgi-app -f mapproxy.yaml /mapproxy/app.py"
-su $USER_NAME -c "uwsgi --ini /uwsgi.conf"
-#su $USER_NAME -c "/venv/bin/mapproxy-util serve-develop -b 0.0.0.0:8080 mapproxy.yaml"
+#su $USER_NAME -c "uwsgi --ini /uwsgi.conf"
+su $USER_NAME -c "/venv/bin/mapproxy-util serve-develop -b 0.0.0.0:8080 mapproxy.yaml"


### PR DESCRIPTION
This makes my browser able to load `localhost:8080/demo/` which I think is a better default setting.