### PR TITLE
Apply docker prod mode standard

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 mapproxy
+configuration/cache_data

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get -y update
 #-------------Application Specific Stuff ----------------------------------------------------
 
 RUN apt-get install -y \
+    gettext \
     python-yaml \
     libgeos-dev \
     python-lxml \
@@ -28,6 +29,7 @@ ENV \
     # Run using uwsgi. This is the default behaviour. Alternatively run using the dev server. Not for production settings
     PRODUCTION=true
 
+ADD uwsgi.ini /settings/uwsgi.default.ini
 ADD start.sh /start.sh
 RUN chmod 0755 /start.sh
 RUN mkdir -p /mapproxy /settings
@@ -36,4 +38,5 @@ RUN groupadd -r mapproxy -g 10001 && \
 RUN chown -R mapproxy:mapproxy /mapproxy /settings /start.sh
 VOLUME [ "/mapproxy"]
 USER mapproxy
-CMD /start.sh
+ENTRYPOINT [ "/start.sh" ]
+CMD ["mapproxy-util", "serve-develop", "-b", "0.0.0.0:8080", "mapproxy.yaml"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The cached wms tiles will be written to ``./configuration/cache_data`` externall
 defined by the mapproxy.yaml.
 
 **Note** that the mapproxy containerised application will run as the user that
-owns the /mapproxy folder.
+owns the /mapproxy folder. The UID:GID of the process will be 1000:10001. If you serve existing ``./configuration`` folder, you need to set the folder permission with `chown -R 1000:10001 ./configuration` from this directory.
 
 # docker-compose
 You can set up the services using the docker-compose. The docker-compose sets up the QGIS server 
@@ -67,8 +67,10 @@ A index.html is provided in the web folder to preview the layers in mapproxy.
 
 # Reverse proxy
 
-The mapproxy container 'speaks' ``uwsgi`` so you need to put nginx in front of it
-(try the ``nginx docker container``). A sample configuration (via linked
+The mapproxy container can 'speaks' ``uwsgi`` protocol so you can also put nginx in front of it 
+to receive http request and translate it to uwsgi
+(try the ``nginx docker container``). However our sample configuration by default 
+make `uwsgi` uses `http` socket instead of `socket` parameter (uwsgi protocol). A sample configuration (via linked
 containers) that will forward traffic into the uwsgi container, adding the appropriate 
 headers as needed is provided via docker-compose
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,12 @@ services:
       - PRODUCTION=true
       - PROCESSES=4
       - THREADS=10
+    user: "1000:10001"
     volumes:
       - ./configuration:/mapproxy
     depends_on:
       - map
-  ngnix:
+  nginx:
     image: nginx
     volumes:
       - ./web:/web

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,0 +1,17 @@
+[uwsgi]
+chdir = /mapproxy
+pyargv = /mapproxy.yaml
+wsgi-file = app.py
+pidfile=/tmp/mapproxy.pid
+http = 0.0.0.0:8080
+processes = $PROCESSES
+cheaper = 2
+enable-threads = true
+threads = $THREADS
+master = true
+wsgi-disable-file-wrapper = true
+memory-report = true
+harakiri = 60
+chmod-socket = 664
+uid = 1000
+gid = 10001


### PR DESCRIPTION
- Allow config file overrides for /settings/uwsgi.ini
- Use standard ENTRYPOINT and CMD separation
- Add notes in README.md regarding file system security context
- Add notes in README.md about our choice to use http socket in uwsgi
- Explicitly declare what UID:GID mapping the container
  will use by default in docker-compose.yml
  
  I will explain the reasoning in a PR review