### PR TITLE
Fix incorrect uwsgi.ini URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ you most likely want to set this to `http://minio:9000/` or the URL of your exte
 
 if running in production you can specify any uwsgi parameters.
 
-You can mount the [uwsgi.ini](https://github.com/kartoza/docker-mapproxy/blob/master/uwsgi.ini) to
+You can mount the [uwsgi.ini](https://github.com/kartoza/docker-mapproxy/blob/master/build_data/uwsgi.ini) to
 a path inside the container thus overriding a lot of the uwsgi default settings.
 
 ```bash
@@ -119,7 +119,7 @@ An `index.html` is provided in the web folder to preview the layers in mapproxy.
 
 # Reverse proxy
 
-The mapproxy container can 'speaks' ``uwsgi`` protocol so you can also put nginx in front of it
+The mapproxy container 'speaks' ``uwsgi`` protocol so you can also put nginx in front of it
 to receive http request and translate it to uwsgi
 (try the ``nginx docker container``). However, our sample configuration by default
 make `uwsgi` uses `http` socket instead of `socket` parameter (uwsgi protocol). A sample configuration (via linked

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -70,7 +70,7 @@ EOF
     function uwisgi_config (){
        DATA_PATH=$1
        if [[ ! -f /settings/uwsgi.ini ]]; then
-          echo -e "\e[32m No custom uwsgi.ini file, setup using default one from  \033[0m \e[1;31m https://github.com/kartoza/docker-mapproxy/blob/master/uwsgi.ini \033[0m"
+          echo -e "\e[32m No custom uwsgi.ini file, setup using default one from  \033[0m \e[1;31m https://github.com/kartoza/docker-mapproxy/blob/master/build_data/uwsgi.ini \033[0m"
           # If it doesn't exists, copy from /mapproxy directory if exists
           if [[ -f ${DATA_PATH}/uwsgi.ini ]]; then
             cp -f "${DATA_PATH}"/uwsgi.ini /settings/uwsgi.ini


### PR DESCRIPTION
The sample uwsgi.ini file seems to have been moved to the build_data directory:

https://github.com/kartoza/docker-mapproxy/blob/master/build_data/uwsgi.ini

I updated and fixed the references in the readme and the start.sh script accordingly.